### PR TITLE
Enhance CI and composer requirement settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ php:
 - 7.2
 - 7.3
 
+sudo: required
+
 services:
 - postgresql
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         }
     ],
     "require": {
-        "php": "^7.1"
+        "php": "^7.2",
+        "ext-pgsql": "*"
     },
     "require-dev": {
         "infection/infection": "^0.13",


### PR DESCRIPTION
# Changed log
- Add `ext-pgsql` inside `require` block on `composer.json` to check whether the `pgsql` extension is installed.
- It seems that the CI do tests for `php-7.2` and `php-7.3`.
The version requires `php-7.2` at least. Changing into `php-7.2` on `composer.json`.
- It uses the privilege user during Travis CI build and add `sudo: required` on `.travis.yml` setting.